### PR TITLE
Support aliased boolean class bindings as per README, this now works:

### DIFF
--- a/ampersand-view.js
+++ b/ampersand-view.js
@@ -339,7 +339,7 @@ _.extend(View.prototype, {
                             var classList = classes(el);
                             var prevVal;
                             if (_.isBoolean(newVal)) {
-                                classList.toggle(propertyName, newVal);
+                                classList.toggle(attributeName || propertyName, newVal);
                             } else {
                                 prevVal = model.previous(propertyName);
                                 if (prevVal) classList.remove(prevVal);

--- a/test/main.js
+++ b/test/main.js
@@ -189,6 +189,29 @@ test('class bindings', function (t) {
     t.end();
 });
 
+test('class bindings, with renamed class', function (t) {
+    var model = new Model();
+    model.set({
+        fireDanger: 'high',
+        active: true
+    });
+    var view = getView({
+        template: '<li></li>',
+        bindings: {
+            active: ['', 'class', 'active-class-name']
+        }
+    }, model);
+
+    var className = view.el.className;
+    t.ok(contains(className, 'active-class-name'));
+
+    model.set('active', false);
+    className = view.el.className;
+    t.ok(!contains(className, 'active-class-name'));
+
+    t.end();
+});
+
 test('classList bindings', function (t) {
     var model = new Model();
     model.set({


### PR DESCRIPTION
```
bindings: {
  active: ['li', 'class', 'new-name-for-class']
  }
```

Fixes: #11 
