### PR TITLE
remove backbone-events-standalone dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .DS_Store
 npm-debug.log
+.idea

--- a/ampersand-view.js
+++ b/ampersand-view.js
@@ -1,5 +1,4 @@
 var State = require('ampersand-state');
-var Events = require('backbone-events-standalone');
 var CollectionView = require('ampersand-collection-view');
 var domify = require('domify');
 var _ = require('underscore');

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "dependencies": {
     "ampersand-collection-view": "^1.0.0",
     "ampersand-state": "^4.2.7",
-    "backbone-events-standalone": "^0.2.1",
     "component-classes": "^1.0.0",
     "ampersand-dom-bindings": "^2.1.0",
     "domify": "^1.0.0",


### PR DESCRIPTION
this is probably just a holdover from days past. I was reading through the code and noticed that it wasn’t being used, so I went ahead and removed it.
