### PR TITLE
Call "template" method with scope set

### DIFF
--- a/ampersand-view.js
+++ b/ampersand-view.js
@@ -284,7 +284,7 @@ _.extend(View.prototype, {
     renderWithTemplate: function (context, templateArg) {
         var template = templateArg || this.template;
         if (!template) throw new Error('Template string or function needed.');
-        var newDom = _.isString(template) ? template : template(context || this);
+        var newDom = _.isString(template) ? template : template.call(this, context || this);
         if (_.isString(newDom)) newDom = domify(newDom);
         var parent = this.el && this.el.parentNode;
         if (parent) parent.replaceChild(newDom, this.el);


### PR DESCRIPTION
After the second time getting bit by this, figured it was time to fix it.  I left the context variable being passed as an argument since to avoid it being a breaking change.

Currently template is called without a scope, so "this" refers to window, rather than the object the method was defined in.

This avoids writing non-intuitive code such as:

```
AmpersandView.extend({
    values: [1,2,3],
    template: function(constext){
         return context.values.join(", ")
    }
})
```

In favor of:

```
AmpersandView.extend({
    values: [1,2,3],
    template: function(){
         return this.values.join(", ")
    }
})
```
