### PR TITLE
Fixed sorting test case

### DIFF
--- a/test/renderCollection.js
+++ b/test/renderCollection.js
@@ -117,6 +117,7 @@ test('sort', function (t) {
         return model.get('name');
     };
     view.collection.sort();
+    view.render();
     t.equal(view.numberRendered(), view.collection.length);
     var domIds = [];
     view.getAll('li').forEach(function (el) {


### PR DESCRIPTION
View wasn't rerendered after sorting, therefore results were inaccurate.
