### PR TITLE
Returning collectionView on renderCollection().

### DIFF
--- a/ampersand-view.js
+++ b/ampersand-view.js
@@ -349,8 +349,7 @@ _.extend(View.prototype, {
         }, opts);
         var collectionView = new CollectionView(config);
         collectionView.render();
-        this.registerSubview(collectionView);
-        return collectionView;
+        return this.registerSubview(collectionView);
     }
 });
 


### PR DESCRIPTION
To make it possible to track your model views of your collections. It is very handy to have a reference to the collectionView. Currently you can only use a syntax like this._subviews[1].views but this is rather hacky, nor do you exactly know what view it is.

By giving renderCollection() a return value of collectionView you can easily do 
this.views = this.renderCollection();
_.each(this.views, function(view){});
