### PR TITLE
Subview shorthands for assigning model and/or collection

### DIFF
--- a/ampersand-view.js
+++ b/ampersand-view.js
@@ -250,14 +250,18 @@ _.extend(View.prototype, {
         var self = this;
         var opts = {
             selector: subview.container || '[role="' + subview.role + '"]',
-            waitFor: subview.waitFor || '',
+            waitFor: subview.waitFor || subview.model || subview.collection || '',
             prepareView: subview.prepareView || function (el) {
-                return new subview.constructor({
+                
+                var viewOpts = {
                     el: el,
-                    parent: self,
-                    model: subview.model ? getPath(self, subview.model) : null,
-                    collection: subview.collection ? getPath(self, subview.collection) : null
-                });
+                    parent: self
+                };
+                
+                if(subview.model) viewOpts.model = getPath(self, subview.model);
+                if(subview.collection) viewOpts.collection = getPath(self, subview.collection);
+                
+                return new subview.constructor(viewOpts);
             }
         };
         function action() {

--- a/ampersand-view.js
+++ b/ampersand-view.js
@@ -254,7 +254,9 @@ _.extend(View.prototype, {
             prepareView: subview.prepareView || function (el) {
                 return new subview.constructor({
                     el: el,
-                    parent: self
+                    parent: self,
+                    model: subview.model ? getPath(self, subview.model) : null,
+                    collection: subview.collection ? getPath(self, subview.collection) : null
                 });
             }
         };

--- a/ampersand-view.js
+++ b/ampersand-view.js
@@ -248,28 +248,51 @@ _.extend(View.prototype, {
     // the `waitFor` if need be.
     _parseSubview: function (subview, name) {
         var self = this;
+
+        // waitFor can be both {array} and {string}, but
+        // internaly it needs to be an {array}
+        var waitFor = typeof subview.waitFor === 'string' ? [subview.waitFor] : subview.waitFor;
+        if(!waitFor) waitFor = [];
+
+        // add subview collection and/or model to waitFor.
+        if(subview.model) waitFor.push(subview.model);
+        if(subview.collection) waitFor.push(subview.collection);
+
         var opts = {
             selector: subview.container || '[role="' + subview.role + '"]',
-            waitFor: subview.waitFor || subview.model || subview.collection || '',
-            prepareView: subview.prepareView || function (el) {
-                
+            waitFor: waitFor,
+            model: subview.model,
+            collection: subview.collection,
+            prepareView: subview.prepareView || function (el, model, collection) {
+
                 var viewOpts = {
                     el: el,
                     parent: self
                 };
-                
-                if(subview.model) viewOpts.model = getPath(self, subview.model);
-                if(subview.collection) viewOpts.collection = getPath(self, subview.collection);
-                
+
+                if(model) viewOpts.model = getPath(self, model);
+                if(collection) viewOpts.collection = getPath(self, collection);
+
                 return new subview.constructor(viewOpts);
             }
         };
         function action() {
             var el, subview;
             // if not rendered or we can't find our element, stop here.
-            if (!this.el || !(el = this.get(opts.selector))) return;
-            if (!opts.waitFor || getPath(this, opts.waitFor)) {
-                subview = this[name] = opts.prepareView.call(this, el);
+            if (!this.el || !(el = this.get(opts.selector))){
+                return;
+            }
+
+            // Iterate trough waitFor {array} and check if all are loaded i.e. not undefined.
+            var isWaitForLoaded = !_.chain(opts.waitFor)
+                .map(function(str){
+                    return getPath(self, str);
+                })
+                .contains(undefined)
+                .value();
+
+            if (isWaitForLoaded) {
+                subview = this[name] = opts.prepareView.call(this, el, opts.model, opts.collection);
                 subview.render();
                 this.registerSubview(subview);
                 this.off('change', action);

--- a/test/main.js
+++ b/test/main.js
@@ -619,6 +619,53 @@ test('make sure subviews dont fire until their `waitFor` is done', function (t) 
     t.end();
 });
 
+test('set subview model via shorthand', function (t) {
+
+    var User = AmpersandModel.extend({
+        props: {
+            name: 'string'
+        }
+    });
+
+    var UserView = AmpersandView.extend({
+        autoRender: true,
+        template: '<span role="name">noname</span>',
+        bindings : {
+            'model.name': {
+                'type': 'text',
+                'role': 'name'
+            }
+        }
+    });
+
+    var View = AmpersandView.extend({
+        template: '<div><span class="container"></span></div>',
+        autoRender: true,
+        props: {
+            user: 'state',
+        },
+        subviews: {
+            user: {
+                container: '.container',
+                constructor: UserView,
+                model: 'user'
+            }
+        }
+    });
+
+    var view = new View();
+    t.equal(view.el.outerHTML, '<div><span class="container"></span></div>');
+
+
+    var me = new User({
+        name: 'janjarfalk',
+    });
+    view.user = me;
+    t.equal(view.el.outerHTML, '<div><span role="name">janjarfalk</span></div>');
+
+    t.end();
+});
+
 test('make sure template can return a dom node', function (t) {
     var Sub = AmpersandView.extend({
         template: function () {

--- a/test/main.js
+++ b/test/main.js
@@ -579,10 +579,11 @@ test('make sure subviews dont fire until their `waitFor` is done', function (t) 
     });
 
     var View = AmpersandView.extend({
-        template: '<div><span class="container"></span><span role="sub"></span></div>',
+        template: '<div><span class="container"></span><span role="sub"></span><span role="sub3"></span></div>',
         autoRender: true,
         props: {
-            model2: 'state'
+            model2: 'state',
+            model3: 'state'
         },
         subviews: {
             sub1: {
@@ -594,17 +595,25 @@ test('make sure subviews dont fire until their `waitFor` is done', function (t) 
                 waitFor: 'model2',
                 role: 'sub',
                 constructor: Sub
+            },
+            sub3: {
+                waitFor: ['model2', 'model3'],
+                role: 'sub3',
+                constructor: Sub
             }
         }
     });
     var view = new View();
-    t.equal(view._events.change.length, 2);
-    t.equal(view.el.outerHTML, '<div><span class="container"></span><span role="sub"></span></div>');
+    t.equal(view._events.change.length, 3);
+    t.equal(view.el.outerHTML, '<div><span class="container"></span><span role="sub"></span><span role="sub3"></span></div>');
     view.model = new Model();
-    t.equal(view._events.change.length, 1);
-    t.equal(view.el.outerHTML, '<div><span>yes</span><span role="sub"></span></div>');
+    t.equal(view._events.change.length, 2);
+    t.equal(view.el.outerHTML, '<div><span>yes</span><span role="sub"></span><span role="sub3"></span></div>');
     view.model2 = new Model();
-    t.equal(view.el.outerHTML, '<div><span>yes</span><span>yes</span></div>');
+    t.equal(view.el.outerHTML, '<div><span>yes</span><span>yes</span><span role="sub3"></span></div>');
+    t.equal(view._events.change.length, 1);
+    view.model3 = new Model();
+    t.equal(view.el.outerHTML, '<div><span>yes</span><span>yes</span><span>yes</span></div>');
     t.notOk(view._events.change);
 
     t.end();


### PR DESCRIPTION
```javascript
subviews: {
        user: {
            container: '[role=user]',
            constructor: UserView,
            model: 'model.user' // Will set subview model to model.user and wait for it.
        },
        todos: {
            container: '[role=todos]',
            constructor: TodoView,
            collection: 'model.todos' // Will set subview collection to model.todos and wait for it.
        }
    }
```