### PR TITLE
default renderSubview and renderCollection containers to this.el

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ render: function () {
 
 * `collection` {Backbone Collection} The instantiated collection we wish to render.
 * `ItemView` {View Constructor | Function} The view constructor that will be instantiated for each model in the collection or a function that will return an instance of a given constructor. `options` object is passed as a first argument to a function, which can be used to access `options.model` and determine which view should be instantiated. This view will be used with a reference to the model and collection and the item view's `render` method will be called with an object containing a reference to the containerElement as follows: `.render({containerEl: << element >>})`.
-* `containerEl` {Element} The element that should hold the collection of views.
+* containerEl {Element | String} This can either be an actual DOM element or a CSS selector string such as `.container`. If a string is passed ampersand-view runs `this.query('YOUR STRING')` to try to grab the element that should contain the collection of views. If you don't supply a `containerEl` it will default to `this.el`.
 * `viewOptions` {Object} [optional] Additional options 
     * `viewOptions` {Object} Options object that will get passed to the `initialize` method of the individual item views.
     * `filter` {Function} [optional] Function that will be used to determine if a model should be rendered in this collection view. It will get called with a model and you simply return `true` or `false`.
@@ -458,7 +458,7 @@ Removes a view from the DOM, and calls `stopListening` to remove any bound event
 ### renderSubview `view.renderSubview(viewInstance, containerEl)`
 
 * viewInstance {Object} Any object with a `.remove()`, `.render()` and an `.el` property that is the DOM element for that view. Typically this is just an instantiated view.
-* containerEl {Element | String} This can either be an actual DOM element or a CSS selector string such as `.container`. If a string is passed human view runs `this.query('YOUR STRING')` to try to grab the element that should contain the sub view.
+* containerEl {Element | String} This can either be an actual DOM element or a CSS selector string such as `.container`. If a string is passed ampersand-view runs `this.query('YOUR STRING')` to try to grab the element that should contain the sub view. If you don't supply a `containerEl` it will default to `this.el`.
 
 This method is just sugar for the common use case of instantiating a view and putting in an element within the parent.
 

--- a/ampersand-view.js
+++ b/ampersand-view.js
@@ -215,7 +215,7 @@ _.extend(View.prototype, {
         }
         this.registerSubview(view);
         view.render();
-        container.appendChild(view.el);
+        (container || this.el).appendChild(view.el);
         return view;
     },
 
@@ -349,7 +349,7 @@ _.extend(View.prototype, {
         var containerEl = (typeof container === 'string') ? this.query(container) : container;
         var config = _.extend({
             collection: collection,
-            el: containerEl,
+            el: containerEl || this.el,
             view: ViewClass
         }, opts);
         var collectionView = new CollectionView(config);

--- a/test/main.js
+++ b/test/main.js
@@ -77,6 +77,39 @@ test('registerSubview', function (t) {
     t.end();
 });
 
+test('registerSubview: default container to this.el', function (t) {
+    var removeCalled = 0;
+    var SubView = AmpersandView.extend({
+        template: '<div></div>',
+        render: function () {
+            this.renderWithTemplate();
+            this.el.className = 'subview';
+        },
+        remove: function () {
+            removeCalled++;
+        }
+    });
+    var View = AmpersandView.extend({
+        template: '<section></section>',
+        render: function () {
+            this.renderWithTemplate();
+            this.renderSubview(new SubView());
+            this.renderSubview(new SubView());
+        }
+    });
+
+    var main = new View({
+        el: document.createElement('div')
+    });
+
+    main.render();
+    t.equal(main.queryAll('.subview').length, 2);
+    t.equal(main.el.childNodes.length, 2);
+    main.remove();
+    t.equal(removeCalled, 2);
+    t.end();
+});
+
 test('listen to and run', function (t) {
     t.plan(1);
     var model = new Model({

--- a/test/renderCollection.js
+++ b/test/renderCollection.js
@@ -59,6 +59,17 @@ var MainView = AmpersandView.extend({
     }
 });
 
+var MainViewUl = MainView.extend({
+    initialize: function () {
+        this.el = document.createElement('ul');
+        this.collection = new Collection(getModelData());
+    },
+    render: function (opts) {
+        this.collectionView = this.renderCollection(this.collection, ItemView);
+        return this;
+    }
+});
+
 function getModelData() {
     return [
         'Henrik Joreteg',
@@ -90,6 +101,14 @@ test('collection view is returned', function (t) {
     view.render();
     t.equal(typeof view.collectionView, 'object');
     t.equal(view.collectionView.collection.length, 5);
+    t.end();
+});
+
+test('this.el is default', function (t) {
+    var view = new MainViewUl();
+    view.render();
+    t.equal(view.collection.length, 5);
+    t.equal(view.numberRendered(), view.collection.length);
     t.end();
 });
 


### PR DESCRIPTION
Closes #54
- Makes `renderSubview` and `renderCollection` default to `this.el` for container if its not supplied
- Tests for both
- Update docs to specify defaults
