### PR TITLE
Update renderCollection to ensure that childViews have a proper 'parent' property

### DIFF
--- a/ampersand-view.js
+++ b/ampersand-view.js
@@ -350,7 +350,11 @@ _.extend(View.prototype, {
         var config = _.extend({
             collection: collection,
             el: containerEl || this.el,
-            view: ViewClass
+            view: ViewClass,
+            parent: this,
+            viewOptions: {
+                parent: this
+            }
         }, opts);
         var collectionView = new CollectionView(config);
         collectionView.render();

--- a/test/renderCollection.js
+++ b/test/renderCollection.js
@@ -223,3 +223,27 @@ test('child view can choose to insert self', function (t) {
     view.remove();
     t.end();
 });
+
+test('child view `parent` should be parent view not collection view, when using `renderCollection()`', function (t) {
+    var Child = AmpersandView.extend({
+        template: '<li></li>',
+        initialize: function () {
+            t.equal(this.parent, view);
+            t.end();
+        }
+    });
+
+    var View = AmpersandView.extend({
+        initialize: function () {
+            this.el = document.createElement('div');
+            this.collection = new Collection([{id: 9}]);
+        },
+        render: function (opts) {
+            this.el.innerHTML = '<ul></ul>';
+            this.collectionView = this.renderCollection(this.collection, Child, this.query('ul'), {parent: this});
+        }
+    });
+
+    var view = new View();
+    view.render();
+});


### PR DESCRIPTION
From a view rendered by `renderCollection` we should still maintain a `.parent` property just like in with other subviews.
