### PR TITLE
Guard against empty _subviews for #66

### DIFF
--- a/ampersand-view.js
+++ b/ampersand-view.js
@@ -135,7 +135,7 @@ _.extend(View.prototype, {
     remove: function () {
         var parsedBindings = this._parsedBindings;
         if (this.el && this.el.parentNode) this.el.parentNode.removeChild(this.el);
-        _.chain(this._subviews).flatten().invoke('remove');
+        if (this._subviews) _.chain(this._subviews).flatten().invoke('remove');
         this.stopListening();
         // TODO: Not sure if this is actually necessary.
         // Just trying to de-reference this potentially large


### PR DESCRIPTION
Underscore 1.7.0 has changed how flatten(undefined) [behaves](https://github.com/jashkenas/underscore/issues/1875), so we need to guard against it in case someone has underscore 1.7 installed in their project.
