### PR TITLE
Allow for passing templates on view initialization. Fixes #75

### DIFF
--- a/ampersand-view.js
+++ b/ampersand-view.js
@@ -22,6 +22,7 @@ function View(attrs) {
         this._handleElementChange();
     }
     this._initializeSubviews();
+    this.template = attrs.template || this.template;
     this.initialize.apply(this, arguments);
     this.set(_.pick(attrs, viewOptions));
     if (this.autoRender && this.template) {

--- a/test/main.js
+++ b/test/main.js
@@ -656,6 +656,22 @@ test('make sure template can return a dom node', function (t) {
     t.end();
 });
 
+test('template can be passed as viewOption', function (t) {
+    t.plan(1);
+
+    var View = AmpersandView.extend({
+        autoRender: true
+    });
+
+    var view = new View({
+        template: '<span></span>'
+    });
+
+    t.equal(view.el.outerHTML, '<span></span>');
+
+    t.end();
+});
+
 test('events are bound if there is an el in the constructor', function (t) {
     t.plan(1);
     var event = document.createEvent("MouseEvent");


### PR DESCRIPTION
Issue mentioned here https://github.com/AmpersandJS/ampersand-view/issues/75
What I'm only not quite sure is whether we should make it prior or after `initialize` function itself.
