### PR TITLE
Add examples of extending superclass properties and methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ explicitly call the `initialize` of the superclass at the right time:
 ```
 var SuperheroRowView = PersonRowView.extend({
   initialize: function () {
-    PersonRowView.prototype.initialize.call(this, arguments);
+    PersonRowView.prototype.initialize.apply(this, arguments);
     doSomeOtherStuffHere();
   })
 });
@@ -299,7 +299,7 @@ explicitly call the `render` of the superclass at the right time:
 ```
 var SuperheroRowView = PersonRowView.extend({
   render: function () {
-    PersonRowView.prototype.render.call(this, arguments);
+    PersonRowView.prototype.render.apply(this, arguments);
     doSomeOtherStuffHere();
   })
 });


### PR DESCRIPTION
Unlike props/derived/... from ampersand-state, view properties such as `bindings`  and `events`  aren't merged with the ones from the superclass. This is something I occasionally want to do.
Similarly, I sometimes want to extend behaviour of a base class in `render()` and `initialize()`.

Being relatively new to this, it wasn't immediately obvious to me how to do this, and an example would have helped a lot, so I documented the way I ended up doing this.

Some of this may border on basic JavaScript knowledge (although knowing what View.extend() does behind the screens isn't), but I still think it has a place somewhere in some documentation, and this is the best place I could find.
