### PR TITLE
fix `renderCollection() ` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,10 +363,10 @@ var AlternativeMainView = AmpersandView.extend({
         this.renderWithTemplate(this);
         this.renderCollection(this.collection, function (options) {
             if (options.model.isAlternative) {
-                return new AlternativeMainView(options);
+                return new AlternativeItemView(options);
             }
 
-            return new MainView(options);
+            return new ItemView(options);
         }, this.el.querySelector('.itemContainer'), opts);
         return this;
     }


### PR DESCRIPTION
The second arg of  `view.renderCollection()` should be an item view or a function that returns an item view. In this example it was returning either of the two main views.
