### PR TITLE
better check for parent reference

### DIFF
--- a/ampersand-view.js
+++ b/ampersand-view.js
@@ -200,10 +200,8 @@ _.extend(View.prototype, {
         // Storage for our subviews.
         this._subviews || (this._subviews = []);
         this._subviews.push(view);
-        // If view has an 'el' it's a single view not
-        // an array of views registered by renderCollection
-        // so we store a reference to the parent view.
-        if (view.el) view.parent = this;
+        // set the parent reference if it has not been set
+        if (!view.parent) view.parent = this;
         return view;
     },
 


### PR DESCRIPTION
this is an attempt to fix #90, which cause a subview to not have a reference to its parent because `registerSubview` is called before `renderSubview`, and at this point, the `view.el` is not defined yet.

this was probably due to a check introduced earlier to not repeatedly assign the `parent` reference for views rendered with `renderCollection`. that comment is taken out in this PR.

this fix is suggested by @aaronmccall.