### PR TITLE
bugfix/report-rendered-when-on-dom

### DIFF
--- a/ampersand-view.js
+++ b/ampersand-view.js
@@ -71,10 +71,10 @@ var BaseState = State.extend({
     },
     derived: {
         rendered: {
-            deps: ['el'],
             fn: function () {
-                return !!this.el;
-            }
+                return document.body.contains(this.el);
+            },
+            cache: false
         },
         hasData: {
             deps: ['model'],

--- a/ampersand-view.js
+++ b/ampersand-view.js
@@ -67,15 +67,14 @@ var BaseState = State.extend({
     props: {
         model: 'state',
         el: 'element',
-        collection: 'collection'
+        collection: 'collection',
+        rendered: {
+            type: 'boolean',
+            required: true,
+            default: false
+        }
     },
     derived: {
-        rendered: {
-            fn: function () {
-                return document.body.contains(this.el);
-            },
-            cache: false
-        },
         hasData: {
             deps: ['model'],
             fn: function () {
@@ -138,6 +137,7 @@ assign(View.prototype, {
     // to populate its element (`this.el`), with the appropriate HTML.
     render: function () {
         this.renderWithTemplate(this);
+        this.rendered = true;
         return this;
     },
 
@@ -158,6 +158,7 @@ assign(View.prototype, {
             delete parsedBindings[modelName];
         });
         this.trigger('remove', this);
+        this.rendered = false;
         return this;
     },
 

--- a/test/main.js
+++ b/test/main.js
@@ -40,16 +40,23 @@ function getView(bindings, model) {
 }
 
 test('rendered attr behavior', function (t) {
+    var caughtRenderEvt = false;
     var detachedEl = document.createElement('div');
     var view = new AmpersandView({
         template: '<span></span>',
         el: detachedEl
     });
-    t.notOk(view.rendered, 'view not rendered prior to render call');
+    view.on('change:rendered', function() {
+        caughtRenderEvt = !caughtRenderEvt;
+    });
+    t.notOk(view.rendered, 'view not `rendered` prior to `render` call');
     view.render();
-    t.notOk(view.rendered, 'view not rendered when `el` not in document');
-    document.body.appendChild(view.el);
-    t.ok(view.rendered, 'view rendered when put on DOM');
+    t.ok(view.rendered, 'view `rendered` post `render` call');
+    t.ok(caughtRenderEvt, 'view `rendered` evt observed on render');
+    view.remove();
+    t.notOk(caughtRenderEvt, 'view `rendered` evt observed on remove');
+    t.notOk(view.rendered, 'view not `rendered` opst to `remove` call');
+
     t.end();
 });
 

--- a/test/main.js
+++ b/test/main.js
@@ -39,6 +39,20 @@ function getView(bindings, model) {
     return view.renderWithTemplate();
 }
 
+test('rendered attr behavior', function (t) {
+    var detachedEl = document.createElement('div');
+    var view = new AmpersandView({
+        template: '<span></span>',
+        el: detachedEl
+    });
+    t.notOk(view.rendered, 'view not rendered prior to render call');
+    view.render();
+    t.notOk(view.rendered, 'view not rendered when `el` not in document');
+    document.body.appendChild(view.el);
+    t.ok(view.rendered, 'view rendered when put on DOM');
+    t.end();
+});
+
 test('registerSubview', function (t) {
     var removeCalled = 0;
     var SubView = AmpersandView.extend({

--- a/test/main.js
+++ b/test/main.js
@@ -56,7 +56,6 @@ test('rendered attr behavior', function (t) {
     view.remove();
     t.notOk(caughtRenderEvt, 'view `rendered` evt observed on remove');
     t.notOk(view.rendered, 'view not `rendered` opst to `remove` call');
-
     t.end();
 });
 


### PR DESCRIPTION
# problem statement
`.rendered` yields true when the view is **not** rendered
 http://requirebin.com/?gist=34edb359882bce0c85ae

# solution
- detect if the `el` is attached to the document body
    - unfortunately, disable caching as event based solutions are apparently out-of-the-question. [1](http://www.w3.org/TR/DOM-Level-3-Events/#event-type-DOMNodeRemovedFromDocument), [2](https://groups.google.com/forum/#!topic/mozilla.dev.platform/L0Lx11u5Bvs)
- add supporting test

i have not tested this in production code yet.  will be making some widgets shortly.  until then, tests passing, ready for review