### PR TITLE
`selector` property vs `container` in subview declarations; updated Readme; updated tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,7 +549,7 @@ module.exports = AmpersandView.extend({
     template: '<div><div></div><ul data-hook="collection-container"></ul></div>',
     subviews: {
         myStuff: {
-            container: '[data-hook=collection-container]',
+            selector: '[data-hook=collection-container]',
             waitFor: 'model.stuffCollection',
             prepareView: function (el) {
                 return new CollectionRenderer({
@@ -559,7 +559,7 @@ module.exports = AmpersandView.extend({
             }
         },
         tab: {
-            container: '[data-hook=switcher]',
+            hook: '[data-hook=switcher]',
             constructor: ViewSwitcher
         }
     }
@@ -568,7 +568,7 @@ module.exports = AmpersandView.extend({
 
 subview declarations consist of:
 
-* container {String} Selector that describes the element within the view that should hold the subview.
+* selector {String} Selector that describes the element within the view that should hold the subview.
 * hook {String} Alternate method for specifying a container element using its `data-hook` attribute. Equivalent to `selector: '[data-hook=some-hook]'`.
 * constructor {ViewConstructor} Any [view conventions compliant](http://ampersandjs.com/learn/view-conventions) view constructor. It will be initialized with `{el: [Element grabbed from selector], parent: [reference to parent view instance]}`. So if you don't need to do any custom setup, you can just provide the constructor.
 * waitFor {String} String specifying they "key-path" (i.e. 'model.property') of the view that must be "truthy" before it should consider the subview ready.

--- a/README.md
+++ b/README.md
@@ -559,7 +559,7 @@ module.exports = AmpersandView.extend({
             }
         },
         tab: {
-            hook: '[data-hook=switcher]',
+            hook: 'switcher',
             constructor: ViewSwitcher
         }
     }

--- a/ampersand-view.js
+++ b/ampersand-view.js
@@ -262,8 +262,12 @@ assign(View.prototype, {
     // the `waitFor` if need be.
     _parseSubview: function (subview, name) {
         var self = this;
+        //backwards compatibility with older versions, when `container` was a valid property (#114)
+        if (subview.container) {
+            subview.selector = subview.container;
+        }
         var opts = {
-            selector: subview.container || '[data-hook="' + subview.hook + '"]',
+            selector: subview.selector || '[data-hook="' + subview.hook + '"]',
             waitFor: subview.waitFor || '',
             prepareView: subview.prepareView || function (el) {
                 return new subview.constructor({
@@ -286,7 +290,6 @@ assign(View.prototype, {
         // we listen for main `change` items
         this.on('change', action, this);
     },
-
 
     // Shortcut for doing everything we need to do to
     // render and fully replace current root element.

--- a/test/main.js
+++ b/test/main.js
@@ -609,7 +609,7 @@ test('subViews declaraction can accept a CSS selector string via `container` pro
         autoRender: true,
         subviews: {
             sub1: {
-                selector: '.container',
+                container: '.container',
                 constructor: Sub
             }
         }

--- a/test/main.js
+++ b/test/main.js
@@ -587,7 +587,29 @@ test('declarative subViews basics', function (t) {
         autoRender: true,
         subviews: {
             sub1: {
-                container: '.container',
+                selector: '.container',
+                constructor: Sub
+            }
+        }
+    });
+    var view = new View();
+
+    t.equal(view.el.innerHTML, '<span></span>');
+
+    t.end();
+});
+
+test('subViews declaraction can accept a CSS selector string via `container` property for backwards compatibility (#114)', function (t) {
+    var Sub = AmpersandView.extend({
+        template: '<span></span>'
+    });
+
+    var View = AmpersandView.extend({
+        template: '<div><div class="container"></div></div>',
+        autoRender: true,
+        subviews: {
+            sub1: {
+                selector: '.container',
                 constructor: Sub
             }
         }
@@ -635,7 +657,7 @@ test('make sure subviews dont fire until their `waitFor` is done', function (t) 
         subviews: {
             sub1: {
                 waitFor: 'model',
-                container: '.container',
+                selector: '.container',
                 constructor: Sub
             },
             sub2: {


### PR DESCRIPTION
Subview declarations now take CSS selector strings via `selector` property, instead of `container` while also maintaining backwards compatibility with using `container`. References to `container`, however, are removed from the Readme. Closes #114