### PR TITLE
bugfix/report-rendered-honestly

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ var SuperheroRowView = PersonRowView.extend({
 });
 ```
 
+ampersand-view triggers a `'render'` event for your convenience, too, if you want to set listeners for it.  The `'render'` and `'remove'` events emitted by this module are merely convenience events, as you may listen solely to `change:rendered` in order to capture the render/remove events in just one listener.
+
 ### renderCollection `view.renderCollection(collection, ItemView, containerEl, [viewOptions])`
 
 * `collection` {Backbone Collection} The instantiated collection we wish to render.
@@ -477,7 +479,7 @@ Shortcut for registering a listener for a model and also triggering it right awa
 
 ### remove `view.remove()`
 
-Removes a view from the DOM, and calls `stopListening` to remove any bound events that the view has `listenTo`'d.  This method also triggers a `remove` event on the view, allowing for listeners (or the view itself) to listen to it and do some action, like cleanup some other resources being used.
+Removes a view from the DOM, and calls `stopListening` to remove any bound events that the view has `listenTo`'d.  This method also triggers a `remove` event on the view, allowing for listeners (or the view itself) to listen to it and do some action, like cleanup some other resources being used.  The view will trigger the `remove` event if `remove()` is overridden.
 
 ```javascript
 initialize : function() {
@@ -598,6 +600,7 @@ You usually don't need to use this, but may wish to if you have multiple views a
 
 ## Changelog
 
+- 8.0.0 Improve `rendered` property behavior.  `rendered` now set as consquence of calling render()/remove() fns, vs. presence of an view element
 - 7.0.0 Replacing use of `role` in lieu of `data-hook` for [accessibility reasons discussed here](https://github.com/AmpersandJS/ampersand/issues/21)
 - [insert period of poor changelog management here], this will not happen again now that ampersand is public.
 - 1.6.3 [diff](https://github.com/HenrikJoreteg/ampersand-view/compare/v1.6.2...v1.6.3) - Move throw statment for too many root elements inside non `<body>` case.

--- a/README.md
+++ b/README.md
@@ -600,7 +600,7 @@ You usually don't need to use this, but may wish to if you have multiple views a
 
 ## Changelog
 
-- 8.0.0 Improve `rendered` property behavior.  `rendered` now set as consquence of calling render()/remove() fns, vs. presence of an view element
+- 8.0.0 Improve `rendered` property behavior.  `rendered` now set after calling render()/remove() fns, vs. old strategy which simply checked for `view.el`
 - 7.0.0 Replacing use of `role` in lieu of `data-hook` for [accessibility reasons discussed here](https://github.com/AmpersandJS/ampersand/issues/21)
 - [insert period of poor changelog management here], this will not happen again now that ampersand is public.
 - 1.6.3 [diff](https://github.com/HenrikJoreteg/ampersand-view/compare/v1.6.2...v1.6.3) - Move throw statment for too many root elements inside non `<body>` case.

--- a/ampersand-view.js
+++ b/ampersand-view.js
@@ -262,7 +262,6 @@ assign(View.prototype, {
         }, this);
     },
 
-
     // ## _initializeSubviews
     // this is called at setup and grabs declared subviews
     _initializeSubviews: function () {

--- a/ampersand-view.js
+++ b/ampersand-view.js
@@ -33,6 +33,7 @@ function View(attrs) {
     this.template = attrs.template || this.template;
     this.initialize.apply(this, arguments);
     this.set(pick(attrs, viewOptions));
+    this._rendered = this.rendered; // prep `rendered` derived cache immediately
     if (this.autoRender && this.template) {
         this.render();
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ampersand-view",
   "description": "A smart base view for Backbone apps, to make it easy to bind collections and properties to the DOM.",
-  "version": "7.4.1",
+  "version": "8.0.0",
   "author": "Henrik Joreteg <henrik@andyet.net>",
   "browser": "./ampersand-view.js",
   "browserify": {

--- a/test/main.js
+++ b/test/main.js
@@ -39,6 +39,47 @@ function getView(bindings, model) {
     return view.renderWithTemplate();
 }
 
+test('standard `rendered` attr behavior', function (t) {
+    var caughtRenderEvt = false;
+    var detachedEl = document.createElement('div');
+    var view = new AmpersandView({
+        template: '<span></span>',
+        el: detachedEl
+    });
+    view.on('change:rendered', function() {
+        caughtRenderEvt = !caughtRenderEvt;
+    });
+    t.notOk(view.rendered, 'view not `rendered` prior to `render()` call');
+    view.render();
+    t.ok(view.rendered, 'view `rendered` post `render()` call');
+    t.ok(caughtRenderEvt, 'view `rendered` evt observed on `render()` call');
+    view.remove();
+    t.notOk(caughtRenderEvt, 'view `rendered` evt observed on `remove()` call');
+    t.notOk(view.rendered, 'view not `rendered` post `remove()` call');
+    t.end();
+});
+
+test('user over-ridden `render()` and `remove()` behavior', function (t) {
+    var view;
+    var RenderTestView = AmpersandView.extend({
+        template: '<span></span>',
+        render: function() {
+            t.ok(true, 'user defined `render()` executed');
+        },
+        remove: function() {
+            t.ok(true, 'user defined `remove()` executed');
+        }
+    });
+    t.plan(4);
+    view = new RenderTestView();
+    view.on('change:rendered', function() {
+        t.ok(true, '`rendered` triggered on custom render/remove');
+    });
+    view.render();
+    view.remove();
+    t.end();
+});
+
 test('registerSubview', function (t) {
     var removeCalled = 0;
     var SubView = AmpersandView.extend({

--- a/test/main.js
+++ b/test/main.js
@@ -1,6 +1,6 @@
 var test = require('tape');
 var AmpersandModel = require('ampersand-model');
-var AmpersandView = require('../ampersand-view.js');
+var AmpersandView = require('../ampersand-view');
 
 var contains = function (str1, str2) {
     return str1.indexOf(str2) !== -1;
@@ -191,7 +191,7 @@ test('caching elements', function(t) {
     }
   });
   var instance = new View(),
-      rendered = instance.render();
+     rendered = instance.render();
   t.equal(instance, rendered);
   t.equal(typeof rendered.span, 'object');
   t.end();


### PR DESCRIPTION
# problem statement
`.rendered` yields true when the view is **not** rendered
 http://requirebin.com/?gist=34edb359882bce0c85ae

# solution
- wrap user provided render/remove setters and getters to manage `rendered` state

this is an alternative implementation to https://github.com/AmpersandJS/ampersand-view/pull/115