### PR TITLE
Extendable `viewOptions`

### DIFF
--- a/ampersand-view.js
+++ b/ampersand-view.js
@@ -33,7 +33,7 @@ function View(attrs) {
     this._initializeSubviews();
     this.template = attrs.template || this.template;
     this.initialize.apply(this, arguments);
-    this.set(pick(attrs, viewOptions));
+    this.set(pick(attrs, result(this, 'viewOptions')));
     if (this.autoRender && this.template) {
         this.render();
     }
@@ -88,13 +88,13 @@ var BaseState = State.extend({
 // Cached regex to split keys for `delegate`.
 var delegateEventSplitter = /^(\S+)\s*(.*)$/;
 
-// List of view options to be merged as properties.
-var viewOptions = ['model', 'collection', 'el'];
-
 View.prototype = Object.create(BaseState.prototype);
 
 // Set up all inheritable properties and methods.
 assign(View.prototype, {
+    // List of view options to be merged as properties.
+    viewOptions: ['model', 'collection', 'el'],
+
     // ## query
     // Get an single element based on CSS selector scoped to this.el
     // if you pass an empty string it return `this.el`.


### PR DESCRIPTION
When extending a view, i often find myself in a situation where i create props that i would like to fill on instantiation, e.g.

```javascript
var View = require('ampersand-view');

var MyView = View.extend({
  props: {
    appendLocation: [ 'string', true, 'body' ]
  },
  initialize: function (opts) {
    this.appendLocation = opts.appendLocation || this.appendLocation;
  }
});

var myView = new MyView({ appendLocation: '#main' });
```

The internal `viewOptions` variable is used to set certain view options as properties.
With this PR, the `viewOptions` variable is no longer internal, but a property of the View's prototype.

Therefore, the aforementioned code can become:

```javascript
var View = require('ampersand-view');

var MyView = View.extend({
  props: {
    appendLocation: [ 'string', true, 'body' ]
  },
  viewOptions: View.prototype.viewOptions.concat([ 'appendLocation' ])
});

var myView = new MyView({ appendLocation: '#main' });
```

This simplifies a lot of my view development and i guess others would benefit from it aswell.

Chaplinjs has a similar property called `optionNames` on their views which i've used a lot in the past:
http://docs.chaplinjs.org/chaplin.view.html

Any opinions?