### PR TITLE
remove unnecessary view options

### DIFF
--- a/ampersand-view.js
+++ b/ampersand-view.js
@@ -32,7 +32,6 @@ function View(attrs) {
     this._initializeSubviews();
     this.template = attrs.template || this.template;
     this.initialize.apply(this, arguments);
-    this.set(pick(attrs, viewOptions));
     this._rendered = this.rendered; // prep `rendered` derived cache immediately
     if (this.autoRender && this.template) {
         this.render();
@@ -95,9 +94,6 @@ var BaseState = State.extend({
 
 // Cached regex to split keys for `delegate`.
 var delegateEventSplitter = /^(\S+)\s*(.*)$/;
-
-// List of view options to be merged as properties.
-var viewOptions = ['model', 'collection', 'el'];
 
 View.prototype = Object.create(BaseState.prototype);
 

--- a/test/main.js
+++ b/test/main.js
@@ -1,5 +1,6 @@
 var test = require('tape');
 var AmpersandModel = require('ampersand-model');
+var AmpersandCollection = require('ampersand-rest-collection');
 var AmpersandView = require('../ampersand-view');
 
 var contains = function (str1, str2) {
@@ -108,6 +109,22 @@ test('user over-ridden `render()` and `remove()` behavior', function (t) {
     });
     view.render();
     view.remove();
+    t.end();
+});
+
+test('Model, collection, and el become properties', function (t) {
+    var model = new Model();
+    var collection = new AmpersandCollection();
+    var el = document.createElement('div');
+    var view = new AmpersandView({
+        model: model,
+        collection: collection,
+        el: el
+    });
+
+    t.equal(view.model, model);
+    t.equal(view.collection, collection);
+    t.equal(view.el, el);
     t.end();
 });
 


### PR DESCRIPTION
Discussion in #123 brought up a good point: the internal `viewOptions` might not be necessary.

Since `model`, `collection`, and `el` are all defined as props on the view, it doesn't seem necessary to also explicitly set the attributes from `viewOptions`.

This adds a test to confirm that `model`, `collection` and `el` all get set on initialization and removes the `viewOptions` variable and the set call that used it.