### PR TITLE
Provide namespace collision errors

### DIFF
--- a/ampersand-view.js
+++ b/ampersand-view.js
@@ -17,6 +17,13 @@ var matches = require('matches-selector');
 var bindings = require('ampersand-dom-bindings');
 var getPath = require('get-object-path');
 
+function safeSet(context, property, value) {
+    if (property in context) {
+        throw new Error('Encountered a namespace collision while setting property `' + property + '`');
+    }
+    context[property] = value;
+    return context;
+}
 
 function View(attrs) {
     this.cid = uniqueId('view');
@@ -283,7 +290,8 @@ assign(View.prototype, {
             // if not rendered or we can't find our element, stop here.
             if (!this.el || !(el = this.query(opts.selector))) return;
             if (!opts.waitFor || getPath(this, opts.waitFor)) {
-                subview = this[name] = opts.prepareView.call(this, el);
+                subview = opts.prepareView.call(this, el);
+                safeSet(this, name, subview);
                 subview.render();
                 this.registerSubview(subview);
                 this.off('change', action);

--- a/test/main.js
+++ b/test/main.js
@@ -592,7 +592,7 @@ test('trigger `remove` when view is removed using on', function (t) {
 });
 
 test('trigger `remove` when view is removed using listenTo', function(t){
-   
+
     var View = AmpersandView.extend({
         template: '<div></div>',
         autoRender: true
@@ -733,4 +733,30 @@ test('events are bound if there is an el in the constructor', function (t) {
     var view = new View({el: document.createElement('div')});
     event.initMouseEvent('click');
     view.el.dispatchEvent(event);
+});
+
+// https://github.com/AmpersandJS/ampersand-view/issues/96
+test('Provide namespace collision errors on subviews property', function (t) {
+    var Sub = AmpersandView.extend({
+        template: '<span></span>',
+    });
+
+    var View = AmpersandView.extend({
+        template: '<div><div class="container"></div></div>',
+        autoRender: true,
+        props: {
+            thing: 'boolean'
+        },
+        subviews: {
+            thing: {
+                container: '.container',
+                constructor: Sub
+            }
+        }
+    });
+
+    t.throws(function () {
+        var view = new View();
+    }, Error, 'Throws collision error');
+    t.end();
 });


### PR DESCRIPTION
This is an initial implementation for handling cases of namespace collisions when assigning properties/methods to `this`.

Lets go over this, and if the implementation is correct, I'll implement it in other areas in this module, as well as update readme & add additional tests.

- Create a safeSet method
- Resolves #96 