### PR TITLE
Attempting to fix subview re-render issue

### DIFF
--- a/ampersand-view.js
+++ b/ampersand-view.js
@@ -155,6 +155,9 @@ assign(View.prototype, {
     // to populate its element (`this.el`), with the appropriate HTML.
     _render: function () {
         this.renderWithTemplate(this);
+        if (this._rendered === true) {
+            this.trigger('change:rendered');
+        }
         this._rendered = true;
         return this;
     },
@@ -306,7 +309,7 @@ assign(View.prototype, {
             }
         }
         // we listen for main `change` items
-        this.on('change', action, this);
+        this.on('change change:rendered', action, this);
     },
 
     // Shortcut for doing everything we need to do to
@@ -400,6 +403,9 @@ assign(View.prototype, {
             set: function(fn) {
                 this._render = function() {
                     fn.apply(this, arguments);
+                    if (this._rendered === true) {
+                        this.trigger('change:rendered');
+                    }
                     this._rendered = true;
                     return this;
                 };

--- a/test/main.js
+++ b/test/main.js
@@ -861,6 +861,37 @@ test('make sure subviews dont fire until their `waitFor` is done', function (t) 
     t.end();
 });
 
+test('make sure subviews are rendered when view instance is rendered more than once', function (t) {
+    var Sub = AmpersandView.extend({
+        template: '<span></span>'
+    });
+
+    var View = AmpersandView.extend({
+        template: '<div><div class="container"></div></div>',
+        autoRender: true,
+        subviews: {
+            sub1: {
+                selector: '.container',
+                constructor: Sub
+            }
+        }
+    });
+    var view = new View();
+
+    t.equal(view.el.innerHTML, '<span></span>');
+
+    view.remove();
+    view.render();
+
+    t.equal(view.el.innerHTML, '<span></span>');
+
+    view.render();
+
+    t.equal(view.el.innerHTML, '<span></span>');
+
+    t.end();
+});
+
 test('make sure template can return a dom node', function (t) {
     var Sub = AmpersandView.extend({
         template: function () {


### PR DESCRIPTION
Attempting to fix #126 

I'm not sure I'd call this code production-ready as it feels quite hackish, but I wanted to demonstrate working code/tests.

Issues encountered:
- `rendered`, as a property, is heavily relied on by other modules. Setting it to false then true in the render cycle would almost certainly cause problems
- Cannot listen to `change:el` because that's altered on every subview render.
- Since subview rendering on every view render is something that, I believe, should happen on every `render()` call, adding the listener and relying on app implementation to trigger `change:rendered` to re-render subviews is not an option.

This definitely needs some more seasoned eyes on it. Suggestions, please!