### PR TITLE
Fix issue #87 - Subviews hash should append el

### DIFF
--- a/ampersand-view.js
+++ b/ampersand-view.js
@@ -287,9 +287,8 @@ assign(View.prototype, {
         var opts = {
             selector: subview.selector || '[data-hook="' + subview.hook + '"]',
             waitFor: subview.waitFor || '',
-            prepareView: subview.prepareView || function (el) {
+            prepareView: subview.prepareView || function () {
                 return new subview.constructor({
-                    el: el,
                     parent: self
                 });
             }
@@ -300,8 +299,12 @@ assign(View.prototype, {
             if (!this.el || !(el = this.query(opts.selector))) return;
             if (!opts.waitFor || getPath(this, opts.waitFor)) {
                 subview = this[name] = opts.prepareView.call(this, el);
-                subview.render();
-                this.registerSubview(subview);
+                if (!subview.el) {
+                    this.renderSubview(subview, el);
+                } else {
+                    subview.render();
+                    this.registerSubview(subview);
+                }
                 this.off('change', action);
             }
         }

--- a/test/main.js
+++ b/test/main.js
@@ -775,6 +775,33 @@ test('declarative subViews basics', function (t) {
     });
     var view = new View();
 
+    t.equal(view.el.innerHTML, '<div class="container"><span></span></div>');
+
+    t.end();
+});
+
+test('declarative subViews basics (with prepareView which tests pre-issue#87 functionality)', function (t) {
+    var Sub = AmpersandView.extend({
+        template: '<span></span>'
+    });
+
+    var View = AmpersandView.extend({
+        template: '<div><div class="container"></div></div>',
+        autoRender: true,
+        subviews: {
+            sub1: {
+                selector: '.container',
+                constructor: Sub,
+                prepareView: function (el) {
+                    return new Sub({
+                        el: el
+                    });
+                }
+            }
+        }
+    });
+    var view = new View();
+
     t.equal(view.el.innerHTML, '<span></span>');
 
     t.end();
@@ -797,7 +824,7 @@ test('subViews declaraction can accept a CSS selector string via `container` pro
     });
     var view = new View();
 
-    t.equal(view.el.innerHTML, '<span></span>');
+    t.equal(view.el.innerHTML, '<div class="container"><span></span></div>');
 
     t.end();
 });
@@ -819,7 +846,7 @@ test('subview hook can include special characters', function (t) {
     });
     var view = new View();
 
-    t.equal(view.el.innerHTML, '<span></span>');
+    t.equal(view.el.innerHTML, '<div data-hook="test.hi-there"><span></span></div>');
 
     t.end();
 });
@@ -853,9 +880,9 @@ test('make sure subviews dont fire until their `waitFor` is done', function (t) 
     t.equal(view.el.outerHTML, '<div><span class="container"></span><span data-hook="sub"></span></div>');
     view.model = new Model();
     t.equal(view._events.change.length, 1);
-    t.equal(view.el.outerHTML, '<div><span>yes</span><span data-hook="sub"></span></div>');
+    t.equal(view.el.outerHTML, '<div><span class="container"><span>yes</span></span><span data-hook="sub"></span></div>');
     view.model2 = new Model();
-    t.equal(view.el.outerHTML, '<div><span>yes</span><span>yes</span></div>');
+    t.equal(view.el.outerHTML, '<div><span class="container"><span>yes</span></span><span data-hook="sub"><span>yes</span></span></div>');
     t.notOk(view._events.change);
 
     t.end();


### PR DESCRIPTION
Previous functionality should be preserved if you pass and set `el` as part of your `prepareView()` function.