### PR TITLE
Add a clear error message for empty templates

### DIFF
--- a/ampersand-view.js
+++ b/ampersand-view.js
@@ -320,6 +320,7 @@ assign(View.prototype, {
         var template = templateArg || this.template;
         if (!template) throw new Error('Template string or function needed.');
         var newDom = isString(template) ? template : template.call(this, context || this);
+        if (!newDom) throw new Error('Empty template');
         if (isString(newDom)) newDom = domify(newDom);
         var parent = this.el && this.el.parentNode;
         if (parent) parent.replaceChild(newDom, this.el);


### PR DESCRIPTION
Accidentally passed an empty template to an Ampersand View and got a cryptic error message that the data type was wrong ("not of type el"). This one-line PR adds a nice error message for this case.

Please let me know if I should write a test or refer to some contribution guidelines. Don't see any links in the README.

Ampersand is great!