### PR TITLE
prevent bogus `remove` event thrown

### DIFF
--- a/ampersand-view.js
+++ b/ampersand-view.js
@@ -31,8 +31,8 @@ function View(attrs) {
     }
     this._initializeSubviews();
     this.template = attrs.template || this.template;
+    this._cache.rendered = false; // prep `rendered` derived cache immediately
     this.initialize.apply(this, arguments);
-    this._rendered = this.rendered; // prep `rendered` derived cache immediately
     if (this.autoRender && this.template) {
         this.render();
     }

--- a/test/main.js
+++ b/test/main.js
@@ -73,7 +73,7 @@ test('event behavior with over-ridden `render` & `remove` fns', function (t) {
     t.equal(renderCount, 1, '`render` triggered exactly once, post- render()');
     view.remove();
     t.equal(removeCount, 1, '`remove` triggered exactly once, post- remove()');
-    t.equal(renderCount, 1, '`render` triggered exactly once, post- remove()');
+    t.equal(renderCount, 1, '`render` not triggered, post- remove()');
     t.end();
 });
 

--- a/test/main.js
+++ b/test/main.js
@@ -42,7 +42,8 @@ function getView(bindings, model) {
 
 test('event behavior with over-ridden `render` & `remove` fns', function (t) {
     var renderCount = 0;
-    t.plan(4);
+    var removeCount = 0;
+    t.plan(7);
     var ChildView = AmpersandView.extend({
         render: function() {
             AmpersandView.prototype.render.call(this);
@@ -64,9 +65,15 @@ test('event behavior with over-ridden `render` & `remove` fns', function (t) {
         ++renderCount;
         t.ok(true, 'view `render` event happened on `render()`');
     });
+    view.on('remove', function(view, value) {
+        ++removeCount;
+    });
     view.render();
+    t.equal(removeCount, 0, '`remove` event not called, pre- or post- render()');
+    t.equal(renderCount, 1, '`render` triggered exactly once, post- render()');
     view.remove();
-    t.equal(1, renderCount, 'over-ridden `render` triggered render just once');
+    t.equal(removeCount, 1, '`remove` triggered exactly once, post- remove()');
+    t.equal(renderCount, 1, '`render` triggered exactly once, post- remove()');
     t.end();
 });
 


### PR DESCRIPTION
`render()`/`remove()` fns have special setters/getters, enabling the over-riding of the functions and still guaranteeing to the user that they get corresponding named events.  i.e. if you override `render()`, you don't need to call `this.trigger('render')` from within.  &-view handles it on your behalf.  `'render'` and `'remove'` events are triggered when the `rendered` bit flips, through the `rendered` derived attribute.  On initialization, I had set an initial `rendered` state on the view, forgetting that it would emit an event!  this PR serves to set that state, but in a _silent_ manner.  Tests updated.