### PR TITLE
persist bindings thru lifecycle. Closes #105

### DIFF
--- a/ampersand-view.js
+++ b/ampersand-view.js
@@ -421,7 +421,7 @@ assign(View.prototype, {
             });
             delete parsedBindings[modelName];
         });
-        this.bindingsSet = true;
+        this.bindingsSet = false;
     },
 
     _upsertBindings: function(attrs) {

--- a/test/main.js
+++ b/test/main.js
@@ -909,3 +909,37 @@ test('events are bound if there is an el in the constructor', function (t) {
     event.initMouseEvent('click');
     view.el.dispatchEvent(event);
 });
+
+test('render, remove, render yields consistent subview behavior', function (t) {
+    t.plan(1);
+    var event = document.createEvent("MouseEvent");
+    var parentEl = document.createElement('div');
+    var childContainerEl = document.createElement('div');
+    childContainerEl.id = 'child_container';
+    parentEl.appendChild(childContainerEl);
+    var Child = AmpersandView.extend({
+        template: function() { return document.createElement('div'); },
+        events: {
+            'click div': 'divClicked'
+        },
+        divClicked: function (e) {
+            t.ok(true, 'child view bindings withheld through parent render/remove/render cycle');
+            t.end();
+        }
+    });
+    var Parent = AmpersandView.extend({
+        template: function() { return parentEl; },
+        subviews: {
+            childv: {
+                selector: '#child_container',
+                constructor: Child
+            }
+        }
+    });
+    var parent = new Parent({ el: document.createElement('div') });
+    parent.render();
+    parent.remove();
+    parent.render();
+    event.initMouseEvent('click');
+    parent.childv.el.dispatchEvent(event);
+});


### PR DESCRIPTION
# problem statement
#105 already adequately describes the issue. bindings get scrapped after remove is called, despite many users wanting to re-render a view instance after it's removed.  such an action will not work in the status quo state

# solution
simple.  do the binding initialization steps as usual, but outsource them to a helper utility.  on render, double check that those bindings still initialized.  on remove, remove them per the status quo (again, oursourced to a helper method).  now on render again, when you do your test, you will find that the bindings have been removed, but we will now restore them.  this preserves the original intent of letting garbage collection happen, but patches the presence of the bindings for next render.  we may consider removing them from `initialize` entirely, though that would take some extra work.