### PR TITLE
Bump ampersand-state to ^5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "ampersand-collection-view": "^1.4.0",
     "ampersand-dom-bindings": "^3.5.0",
-    "ampersand-state": "^4.5.2",
+    "ampersand-state": "^5.0.1",
     "ampersand-version": "^1.0.2",
     "component-classes": "^1.2.4",
     "domify": "^1.3.2",


### PR DESCRIPTION
So we can benefit from https://github.com/AmpersandJS/ampersand-state/pull/235 in ampersand-view.