### PR TITLE
Don't expect a subview's render method to return the view instance

### DIFF
--- a/ampersand-view.js
+++ b/ampersand-view.js
@@ -227,7 +227,8 @@ assign(View.prototype, {
         }
         if (!container) container = this.el;
         this.registerSubview(view);
-        container.appendChild(view.render().el);
+        view.render();
+        container.appendChild(view.el);
         return view;
     },
 


### PR DESCRIPTION
A custom render method for a view may omit returning the view instance, causing `renderSubview` to break, as `el` would be access on an `undefined` return value.

Closes #186 (I think this solves the issue).

Tests pass locally.

This is a non-breaking change.