### PR TITLE
Remove unnecessary dereferencing of bindings

### DIFF
--- a/ampersand-view.js
+++ b/ampersand-view.js
@@ -418,15 +418,6 @@ assign(View.prototype, {
         if (!this.bindingsSet) return;
         if (this._subviews) invokeMap(flatten(this._subviews), 'remove');
         this.stopListening();
-        // TODO: Not sure if this is actually necessary.
-        // Just trying to de-reference this potentially large
-        // amount of generated functions to avoid memory leaks.
-        forEach(parsedBindings, function (properties, modelName) {
-            forEach(properties, function (value, key) {
-                delete parsedBindings[modelName][key];
-            });
-            delete parsedBindings[modelName];
-        });
         this.bindingsSet = false;
     },
 


### PR DESCRIPTION
While working through a related bug, I noticed this bit of code with this `TODO` note in front of it. 

The code previously manually deleted generated binding functions, instead of relying on the browser's garbage collector from automatically taking care of them via dereferencing. If `parsedBindings` (a KeyTreeStore instance) isn't being GC'd normally, then there are likely bigger issues. 

Removing this block still removes this function references as the view, and its `parsedBindings` is removed just fine. A quick test showed that without this code, the JS Heap size did not grow/shrink appreciably.

---
 
Further, the way that this was implemented had a bug. The loop iterated over `parsedBindings` (again, a KeyTreeStore instance), where it should have only been iterating over `parsedBindings.storage`. By iterating over all of `parsedBindings` keys, it meant that the `separator` property was also being "`delete`d":

```js
//this line
delete parsedBindings[modelName][key];

//was eventually always evaluated as this
delete parseBindings.seperator[0];

//which further boils down 
delete "."[0];
```

In most cases, this has no (negative) side effect (other than an extra loop), but I have a case where this actually throws!

Anyway, this is no longer an issue after this PR.

This is probably a semver patch release, as there are no new features, and there are no breaking changes.