### PR TITLE
 Clear _subviews array on _downsertBindings

### DIFF
--- a/ampersand-view.js
+++ b/ampersand-view.js
@@ -416,7 +416,10 @@ assign(View.prototype, {
     _downsertBindings: function() {
         var parsedBindings = this._parsedBindings;
         if (!this.bindingsSet) return;
-        if (this._subviews) invokeMap(flatten(this._subviews), 'remove');
+        if (this._subviews){
+          invokeMap(flatten(this._subviews), 'remove');
+          this._subviews = [];
+        }
         this.stopListening();
         this.bindingsSet = false;
     },

--- a/test/main.js
+++ b/test/main.js
@@ -977,3 +977,22 @@ test('render, remove, render yields consistent subview behavior', function (t) {
     event.initMouseEvent('click');
     parent.childv.el.dispatchEvent(event);
 });
+
+test('the subviews array is empty after the parent view is removed', function(t){
+    t.plan(2);
+    var Child = AmpersandView.extend({
+        template: function() { return document.createElement('div'); }
+    });
+    var Parent = AmpersandView.extend({
+        template: function() { return document.createElement('div'); },
+        render: function(){
+            this.renderWithTemplate();
+            this.renderSubview(new Child(), this.el);
+        }
+    });
+    var parent = new Parent({ el: document.createElement('div') });
+    parent.render();
+    t.equal(parent._subviews.length, 1, 'adds child view to subviews array');
+    parent.remove();
+    t.equal(parent._subviews.length, 0, 'removes child view from subviews array');
+});


### PR DESCRIPTION
As described on #182, the subviews array is not being cleared when the subviews are removed, which means it will contain old view if eventually the parent is re-rendered after remove.