### PR TITLE
Bindings management for custom render and remove 

### DIFF
--- a/ampersand-view.js
+++ b/ampersand-view.js
@@ -405,6 +405,7 @@ assign(View.prototype, {
             },
             set: function(fn) {
                 this._remove = function() {
+                    this._upsertBindings();
                     fn.apply(this, arguments);
                     this._rendered = false;
                     return this;

--- a/ampersand-view.js
+++ b/ampersand-view.js
@@ -390,6 +390,7 @@ assign(View.prototype, {
             },
             set: function(fn) {
                 this._render = function() {
+                    this._upsertBindings();
                     fn.apply(this, arguments);
                     this._rendered = true;
                     return this;
@@ -405,7 +406,6 @@ assign(View.prototype, {
             },
             set: function(fn) {
                 this._remove = function() {
-                    this._upsertBindings();
                     fn.apply(this, arguments);
                     this._rendered = false;
                     return this;

--- a/ampersand-view.js
+++ b/ampersand-view.js
@@ -408,6 +408,7 @@ assign(View.prototype, {
                 this._remove = function() {
                     fn.apply(this, arguments);
                     this._rendered = false;
+                    this._downsertBindings();
                     return this;
                 };
             }

--- a/test/main.js
+++ b/test/main.js
@@ -996,3 +996,23 @@ test('the subviews array is empty after the parent view is removed', function(t)
     parent.remove();
     t.equal(parent._subviews.length, 0, 'removes child view from subviews array');
 });
+
+test('custom render and remove functions should maintain bindings behavior ', function (t) {
+    t.plan(3);
+    var View = AmpersandView.extend({
+        render: function () {
+            this.renderWithTemplate(this);            
+        },
+        remove: function () {
+            if (this.el && this.el.parentNode) this.el.parentNode.removeChild(this.el);
+        },
+        template: function () { return document.createElement('div'); }
+    });
+    var view = new View({ el: document.createElement('div') });
+    view.render();
+    t.equal(view.bindingsSet, true, 'verify initial state, constructor and render calls _upsertBindings, bindingsSet should be true');        
+    view.remove();
+    t.equal(view.bindingsSet, false, 'custom remove calls _downsertBindings and bindingsSet is false');
+    view.render();
+    t.equal(view.bindingsSet, true, 'custom render calls _upsertBindings and bindingsSet is true');  
+});


### PR DESCRIPTION
This is an extension of #181 and the work of @herkyl

resloves #180 

The tests I wrote are the simplest way I could accomplish testing  whether downset/upsert were called in custom render functions. I didn't bother keeping a render count because that is covered in: https://github.com/AmpersandJS/ampersand-view/blob/f63202190fcf670022dfacf19830c1efef847098/test/main.js#L43

I'm back and forth between making this a major/minor SemVer change when this is released. Leaning towards major version bump. I think this qualifies as a breaking change, assuming you had custom render/remove and for whatever reason didn't want to call upsert/downsert for bindings. 

Since I made changes here, looking for a +1 from someone else.